### PR TITLE
uberAgent 7.4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -252,13 +252,13 @@ requests = ">=2.31,<3.0"
 
 [[package]]
 name = "pysigma-backend-uberagent"
-version = "0.3.67"
+version = "0.3.68"
 description = "pySigma uAQL backend"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "pysigma_backend_uberagent-0.3.67-py3-none-any.whl", hash = "sha256:4940faeb074ae9873f122ec806e582804d5c4c543d0831ca9cd0b221f8798265"},
-    {file = "pysigma_backend_uberagent-0.3.67.tar.gz", hash = "sha256:8caf235f9a3cf18f921417fc15f3980f01fee26c62b187aa29f2438227e8115f"},
+    {file = "pysigma_backend_uberagent-0.3.68-py3-none-any.whl", hash = "sha256:b58dd3e0c3afce4362777464ac12a18f00b646b2c76819dcd4efb5703693983c"},
+    {file = "pysigma_backend_uberagent-0.3.68.tar.gz", hash = "sha256:0765feed028e69a5b386e7bc60ec1edf7e8efd6150e8c4d646cc8d415ef650c2"},
 ]
 
 [package.dependencies]
@@ -367,4 +367,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "817def9044383e77ff2749f1a77a8aadaa87c43ee5ce55b13b33fa0854fa64d6"
+content-hash = "cf7b893b9b16239bd6de84c8c8e96c204125fc1a3eac03b890fda3db75458418"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.8"
 pysigma = "^0.11.10"
-pysigma-backend-uberagent = "^0.3.68"
+pysigma-backend-uberagent = "0.3.68"
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.8"
 pysigma = "^0.11.10"
-pysigma-backend-uberagent = "^0.3.67"
+pysigma-backend-uberagent = "^0.3.68"
 
 [tool.poetry.dev-dependencies]
 

--- a/rule-coverage.py
+++ b/rule-coverage.py
@@ -12,12 +12,13 @@ from sigma.collection import SigmaCollection
 from sigma.exceptions import SigmaTransformationError
 
 from sigma.backends.uberagent import uberagent as uberagent_backend
-from sigma.pipelines.uberagent import uberagent600, uberagent610, uberagent620, uberagent700, uberagent710, uberagent720, uberagent730, uberagent_develop
+from sigma.pipelines.uberagent import uberagent600, uberagent610, uberagent620, uberagent700, uberagent710, uberagent720, uberagent730, uberagent740, uberagent_develop
 from sigma.backends.uberagent.exceptions import MissingPropertyException
 
 def get_backends():
     return {
         "uberAgent (develop)": convert_uberagent_develop,
+        "uberAgent 7.4": convert_uberagent740,
         "uberAgent 7.3": convert_uberagent730,
         "uberAgent 7.2": convert_uberagent720,
         "uberAgent 7.1": convert_uberagent710,

--- a/rule-coverage.py
+++ b/rule-coverage.py
@@ -12,7 +12,7 @@ from sigma.collection import SigmaCollection
 from sigma.exceptions import SigmaTransformationError
 
 from sigma.backends.uberagent import uberagent as uberagent_backend
-from sigma.pipelines.uberagent import uberagent600, uberagent610, uberagent620, uberagent700, uberagent710, uberagent720, uberagent730, uberagent740, uberagent_develop
+from sigma.pipelines.uberagent import uberagent620, uberagent700, uberagent710, uberagent720, uberagent730, uberagent740, uberagent_develop
 from sigma.backends.uberagent.exceptions import MissingPropertyException
 
 def get_backends():
@@ -23,18 +23,8 @@ def get_backends():
         "uberAgent 7.2": convert_uberagent720,
         "uberAgent 7.1": convert_uberagent710,
         "uberAgent 7.0": convert_uberagent700,
-        "uberAgent 6.2": convert_uberagent620,
-        "uberAgent 6.1": convert_uberagent610,
-        "uberAgent 6.0": convert_uberagent600,
+        "uberAgent 6.2": convert_uberagent620
     }
-
-
-def convert_uberagent600(rule: SigmaCollection):
-    return uberagent_backend(processing_pipeline=uberagent600()).convert(rule, "conf")
-
-
-def convert_uberagent610(rule: SigmaCollection):
-    return uberagent_backend(processing_pipeline=uberagent610()).convert(rule, "conf")
 
 
 def convert_uberagent620(rule: SigmaCollection):

--- a/rule-coverage.py
+++ b/rule-coverage.py
@@ -43,12 +43,12 @@ def convert_uberagent720(rule: SigmaCollection):
     return uberagent_backend(processing_pipeline=uberagent720()).convert(rule, "conf")
 
 
-def convert_uberagent740(rule: SigmaCollection):
-    return uberagent_backend(processing_pipeline=uberagent740()).convert(rule, "conf")
-
-
 def convert_uberagent730(rule: SigmaCollection):
     return uberagent_backend(processing_pipeline=uberagent730()).convert(rule, "conf")
+
+
+def convert_uberagent740(rule: SigmaCollection):
+    return uberagent_backend(processing_pipeline=uberagent740()).convert(rule, "conf")
 
 
 def convert_uberagent_develop(rule: SigmaCollection):

--- a/rule-coverage.py
+++ b/rule-coverage.py
@@ -53,6 +53,10 @@ def convert_uberagent720(rule: SigmaCollection):
     return uberagent_backend(processing_pipeline=uberagent720()).convert(rule, "conf")
 
 
+def convert_uberagent740(rule: SigmaCollection):
+    return uberagent_backend(processing_pipeline=uberagent740()).convert(rule, "conf")
+
+
 def convert_uberagent730(rule: SigmaCollection):
     return uberagent_backend(processing_pipeline=uberagent730()).convert(rule, "conf")
 


### PR DESCRIPTION
This PR adds uberAgent 7.4 to the sigma rule coverage site. It also drops uberAgent 6.0 and uberAgent 6.1 to be aligned with [uberAgent-config](https://github.com/vastlimits/uberAgent-config/) repository.

A preview of the changes is deployed to my [fork here](https://svnscha.de/uberAgent-Sigma-Rule-Coverage-Explorer/).